### PR TITLE
Fix/Header: show a message when there is no notifications

### DIFF
--- a/front-end-application/src/app/components/header/header.component.css
+++ b/front-end-application/src/app/components/header/header.component.css
@@ -77,3 +77,9 @@ mat-icon {
     width: 30vw;
 }
 
+#nothing-to-show{
+    padding: 8px;
+    padding-left: 10px;
+    padding-right: 10px;
+    color:#255792;
+}

--- a/front-end-application/src/app/components/header/header.component.html
+++ b/front-end-application/src/app/components/header/header.component.html
@@ -44,7 +44,12 @@
                 </ng-template>
             </button>
             <mat-menu #notificationsMenu="matMenu">
+                <div *ngIf="notifications.length>0; else nothingToShow" > 
                 <button mat-menu-item *ngFor="let sol of notifications" (click)="viewSchedule(sol)">The schedule {{sol.startDate}}-{{sol.endDate}}-v{{sol.version}} is {{sol.state}}</button>
+                 </div>
+                <ng-template #nothingToShow>
+                    <mat-menu-item id="nothing-to-show">You don't have any notifications!</mat-menu-item>
+                </ng-template>
             </mat-menu>
         </div>
         <div class="icon-box">


### PR DESCRIPTION
Replacing that sad empty blob with a little message: 

![image](https://user-images.githubusercontent.com/55364581/230749045-406dcda1-2c8f-46f3-8c13-14d78a611a3a.png)


**Please check if this works with notifications, I can't generate a schedule so I cannot test it.** 