### PR TITLE
fix create empty profile behavior

### DIFF
--- a/front-end-application/src/app/components/create-profile-dialog/create-empty-profile-dialog/create-empty-profile-dialog.component.html
+++ b/front-end-application/src/app/components/create-profile-dialog/create-empty-profile-dialog/create-empty-profile-dialog.component.html
@@ -19,7 +19,7 @@
         </mat-error>
     </div>
     <div class="buttons-container">
-        <button mat-raised-button color="warn" [mat-dialog-close]="true">Cancel</button>
+        <button mat-raised-button color="warn" (click)="close()" [mat-dialog-close]="true">Cancel</button>
         <button mat-raised-button color="primary" (click)="create()" [disabled]="hasError()">Submit</button>
     </div>
 </div>

--- a/front-end-application/src/app/components/create-profile-dialog/create-empty-profile-dialog/create-empty-profile-dialog.component.ts
+++ b/front-end-application/src/app/components/create-profile-dialog/create-empty-profile-dialog/create-empty-profile-dialog.component.ts
@@ -53,6 +53,11 @@ export class CreateEmptyProfileDialogComponent {
     })
   }
 
+  close(){
+    this.api.emitNewProfileCreation(false)
+    this.dialogRef.close()
+  }
+
   hasError():boolean{
     return this.nameCtrl.hasError('required') || this.nameExist() || this.nameCtrl.hasError('pattern');
   }


### PR DESCRIPTION
Before this PR a bug arrived when a user does not have a profile and cancel the creation of an empty profile because it closed the profile creation dialog. This PR fixes this behavior to reopen automatically the create dialog when there is no profile